### PR TITLE
Models.Product-tá konvertálás javítás

### DIFF
--- a/docs/Lab-MongoDB/Feladat-1.md
+++ b/docs/Lab-MongoDB/Feladat-1.md
@@ -86,7 +86,7 @@ A forráskód melletti képernyőképeken szerepelnie kell a Neptun kódodnak.
             ID = t.ID.ToString(),
             Name = t.Name,
             Price = t.Price,
-            InStock = t.InStock
+            Stock = t.Stock
         })
         .ToList();
     ```


### PR DESCRIPTION
A Models.Product osztályban Stock a tagváltozó neve nem InStock, ezért fordítási hiba volt.